### PR TITLE
Create make support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install:
 	$(POETRY) install
 
 
-setup:
+
 	@echo "Cloning the repositories..."
 	git clone git@github.com:vladislav/wellplan.git
 	@echo "Navigating to the project directory..."
@@ -30,7 +30,7 @@ migrate:
 	$(POETRY) run alembic upgrade head
 
 
-migrate-downgrade:
+downgrade:
 	@echo "Rolling back Alembic migrations..."
 	$(POETRY) run alembic downgrade -1
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+# Definition of variables
+POETRY := poetry
+
+
+# Basic commands
+install:
+	@echo "Installing project dependencies..."
+	$(POETRY) install
+
+
+setup:
+	@echo "Cloning the repositories..."
+	git clone git@github.com:vladislav/wellplan.git
+	@echo "Navigating to the project directory..."
+	cd wellplan
+	@echo "Running project setup..."
+	make install
+	@echo "Creating .env file..."
+	cp .env.example .env
+
+
+# Command for Alembic
+#migrate-create:
+#Creating a new Alembic migration...
+#$(POETRY) run alembic revision --autogenerate -m "Description of the migration"""
+
+
+migrate:
+	@echo "Running Alembic migrations..."
+	$(POETRY) run alembic upgrade head
+
+
+migrate-downgrade:
+	@echo "Rolling back Alembic migrations..."
+	$(POETRY) run alembic downgrade -1
+
+
+# Run the application
+run:
+	@echo "Starting the application..."
+	$(POETRY) run uvicorn main:app --reload
+
+# Testing
+test:
+	@echo "Running tests..."
+	$(POETRY) run pytest


### PR DESCRIPTION
Я ще не ма справи з makefile і подивившись деякі репо інших розробників знайшов побачив там що використовють коментарі, враховуючи попередження про використання користувацьких команд додав в вигляді коментаря 

# Command for Alembic
#migrate-create:
#Creating a new Alembic migration...
#$(POETRY) run alembic revision --autogenerate -m "Description of the migration"""

але якщо треба видалю. 

З приводу .PHONY - думаю вже додати його після встановлення лінтерів. 
